### PR TITLE
Update patch_op.py

### DIFF
--- a/scim2_models/rfc7644/patch_op.py
+++ b/scim2_models/rfc7644/patch_op.py
@@ -26,6 +26,12 @@ class PatchOperation(ComplexAttribute):
 
     value: Optional[Any] = None
 
+    @model_validator(mode='before')
+    @classmethod
+    def normalize_op(cls, values):
+        if 'op' in values and isinstance(values['op'], str):
+            values['op'] = values['op'].lower()
+        return values
 
 class PatchOp(Message):
     schemas: List[str] = ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]


### PR DESCRIPTION
lower the string value of op so that we can accept any casing.  MSFT Entra capitalizes the first letter for these enum values.